### PR TITLE
🔧 Improve API communication

### DIFF
--- a/src/Pushwoosh.php
+++ b/src/Pushwoosh.php
@@ -58,7 +58,10 @@ class Pushwoosh
         $message->wasSent();
 
         if (isset($response->response->Messages)) {
-            return $response->response->Messages;
+            # Pushwoosh will not assign IDs to messages sent to less than 10 unique devices
+            return array_map(function (string $identifier) {
+                return $identifier !== 'CODE_NOT_AVAILABLE' ? $identifier : null;
+            }, $response->response->Messages);
         }
 
         return [];

--- a/src/PushwooshChannel.php
+++ b/src/PushwooshChannel.php
@@ -59,7 +59,7 @@ class PushwooshChannel
         }
 
         if (!$message instanceof PushwooshMessage) {
-            $message = $this->parseMessage($message);
+            $message = $this->parseMessage($message)->associate($notification);
         }
 
         if (!$recipients instanceof PushwooshRecipient) {


### PR DESCRIPTION
- This PR makes it so that messages sent to Pushwoosh have the same ID as the notification that was used to create them within Laravel
- This PR also fixes an issue where returned message IDs contain `CODE_NOT_AVAILABLE`