### PR TITLE
Add support for message titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Method                           | Description
 `identifier($identifier)`        | Set the Pushwoosh unique identifier (defaults to the notification ID)
 `preset($preset)`                | Set the Pushwoosh preset code
 `throttle($limit)`               | Throttle the rollout (100-1000 pushes per second)
+`title($title)`                  | Set the message title (only on Chrome, Firefox, iOS and Safari)
 `url($url[, $shorten])`          | Set the URL the message should link to
 `useRecipientTimezone()`         | Respect the recipients' timezone when delivering the message
 `with($key, $value[, $platform])`| Add a root level parameter.

--- a/src/PushwooshMessage.php
+++ b/src/PushwooshMessage.php
@@ -20,6 +20,7 @@ class PushwooshMessage implements JsonSerializable
     protected $recipientTimezone;
     protected $shortenUrl;
     protected $timezone;
+    protected $title;
     protected $throughput;
     protected $url;
     protected $when;
@@ -134,13 +135,17 @@ class PushwooshMessage implements JsonSerializable
         $payload = [
             'android_root_params' => $this->androidRootParameters,
             'campaign' => $this->campaign,
+            'chrome_title' => $this->title,
             'content' => $this->content,
             'data' => $this->data,
+            'firefox_title' => $this->title,
             'ignore_user_timezone' => !$this->recipientTimezone,
             'ios_root_params' => $this->iosRootParameters,
+            'ios_title' => $this->title,
             'link' => $this->url,
             'minimize_link' => $this->url ? $this->shortenUrl : null,
             'preset' => $this->preset,
+            'safari_title' => $this->title,
             'send_date' => $this->when,
             'send_rate' => $this->throughput,
             'transactionId' => $this->identifier,
@@ -161,6 +166,19 @@ class PushwooshMessage implements JsonSerializable
     public function preset(string $preset)
     {
         $this->preset = $preset;
+
+        return $this;
+    }
+
+    /**
+     * Set the message title (only supported on Chrome, Firefox, iOS and Safari).
+     *
+     * @param string|null $title
+     * @return $this
+     */
+    public function title(?string $title): self
+    {
+        $this->title = $title;
 
         return $this;
     }


### PR DESCRIPTION
This PR allows you to define a message title for platforms that support it (Google Chrome, Firefox, iOS, Safari)